### PR TITLE
[12.0][FIX] action_cancel resets the workflow

### DIFF
--- a/sale_automatic_workflow/models/account_invoice.py
+++ b/sale_automatic_workflow/models/account_invoice.py
@@ -3,7 +3,7 @@
 # Copyright 2016 Sodexis
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class AccountInvoice(models.Model):
@@ -13,3 +13,10 @@ class AccountInvoice(models.Model):
         comodel_name='sale.workflow.process',
         string='Sale Workflow Process'
     )
+
+    @api.multi
+    def action_cancel(self):
+        for inv in self:
+            if inv.workflow_process_id:
+                inv.workflow_process_id = None
+        return super(AccountInvoice, self).action_cancel()


### PR DESCRIPTION
If someone cancel the invoice reset the "automated workflow" to null to make sure it is not processed anymore.